### PR TITLE
Prevent a problematic char from breaking HTML comments

### DIFF
--- a/packages/mjml-core/src/MJMLRenderer.js
+++ b/packages/mjml-core/src/MJMLRenderer.js
@@ -23,7 +23,7 @@ import React from 'react'
 import ReactDOMServer from 'react-dom/server'
 import warning from 'warning'
 
-const DANGEROUS_CHARS = ['{{', '}}', '<%', '%>', '<=', '=>', '<-', '->', '{%', '%}', '{{{', '}}}']
+const DANGEROUS_CHARS = ['{{', '}}', '<%', '%>', '<=', '=>', '<-', ' ->', '{%', '%}', '{{{', '}}}']
 const SEED = Math.floor(Math.random() * 0x10000000000).toString(16)
 const PLACEHOLDER = `__MJML__${SEED}__`
 const mjmlSanitizer = (mjml) => {


### PR DESCRIPTION
The thin right arrow (`->`) added to `DANGEROUS_CHARS` in PR #751 breaks the closing sequence (`-->`) of HTML comments, which in turn breaks the postrender functions and the resulting HTML.

This PR fixes the issue by adding a space in front of the thin right arrow: `' ->'`

- - -

``` xml
<mjml>
    <mj-body>
        <mj-container background-color="#eee">
            <mj-raw>
                <!-- some comment -->
            </mj-raw>
            <mj-section>
                <mj-column>
                    <mj-button >
                        Don't click me!
                    </mj-button>
                </mj-column>
            </mj-section>
        </mj-container>
    </mj-body>
</mjml>
```

Rendered with MJML 3.3.3:

![3.3.3](https://user-images.githubusercontent.com/4999980/30752684-5926bba6-9fbd-11e7-90a9-de8be037d43d.png)

Rendered with MJML 3.3.4:

![3.3.4](https://user-images.githubusercontent.com/4999980/30752695-65045ab4-9fbd-11e7-99a8-60c1b884ca90.png)

Rendered with the patch:

![fix](https://user-images.githubusercontent.com/4999980/30768871-2222f532-a00f-11e7-9cb3-cb4dbf001891.png)
